### PR TITLE
Added method to generically discover IG Devices

### DIFF
--- a/nat.go
+++ b/nat.go
@@ -41,6 +41,8 @@ func DiscoverGateway() (NAT, error) {
 		return nat, nil
 	case nat := <-discoverUPNP_IG2():
 		return nat, nil
+	case nat := <-discoverUPNP_GenIGDev():
+		return nat, nil
 	case nat := <-discoverNATPMP():
 		return nat, nil
 	case <-time.After(10 * time.Second):


### PR DESCRIPTION
In some cases/networks the goupnp library can completely fail to discover any internet gateway devices, despite their presence (as verified with third party tools).

In this PR I have added a method to generically discover any Internet Gateway specification device on a network and use this as a RootDevice.