### PR TITLE
add DeleteExternalPortMapping to the NAT interface

### DIFF
--- a/nat.go
+++ b/nat.go
@@ -32,6 +32,9 @@ type NAT interface {
 
 	// DeletePortMapping removes a port mapping.
 	DeletePortMapping(protocol string, internalPort int) (err error)
+
+	// DeleteExternalPortMapping removes an external port mapping.
+	DeleteExternalPortMapping(protocol string, externalPort int) (err error)
 }
 
 // DiscoverGateway attempts to find a gateway device.

--- a/natpmp.go
+++ b/natpmp.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/jackpal/gateway"
-	"github.com/jackpal/go-nat-pmp"
+	natpmp "github.com/jackpal/go-nat-pmp"
 )
 
 var (
@@ -107,6 +107,10 @@ func (n *natpmpNAT) AddPortMapping(protocol string, internalPort int, descriptio
 
 func (n *natpmpNAT) DeletePortMapping(protocol string, internalPort int) (err error) {
 	delete(n.ports, internalPort)
+	return nil
+}
+
+func (u *natpmpNAT) DeleteExternalPortMapping(protocol string, externalPort int) error {
 	return nil
 }
 

--- a/upnp.go
+++ b/upnp.go
@@ -257,6 +257,18 @@ func (u *upnp_NAT) DeletePortMapping(protocol string, internalPort int) error {
 	return nil
 }
 
+func (u *upnp_NAT) DeleteExternalPortMapping(protocol string, externalPort int) error {
+	if externalPort <= 0 {
+		return nil
+	}
+	for i, e := range u.ports {
+		if e == externalPort {
+			delete(u.ports, i)
+		}
+	}
+	return u.c.DeletePortMapping("", uint16(externalPort), mapProtocol(protocol))
+}
+
 func (u *upnp_NAT) GetDeviceAddress() (net.IP, error) {
 	addr, err := net.ResolveUDPAddr("udp4", u.rootDevice.URLBase.Host)
 	if err != nil {


### PR DESCRIPTION
useful when we want to unmap a port after a program restart