### PR TITLE
add correct time unit in example

### DIFF
--- a/_examples/nat-tester.go
+++ b/_examples/nat-tester.go
@@ -34,7 +34,7 @@ func main() {
 	}
 	log.Printf("external address: %s", eaddr)
 
-	eport, err := nat.AddPortMapping("tcp", 3080, "http", 60)
+	eport, err := nat.AddPortMapping("tcp", 3080, "http", 60 * time.Second)
 	if err != nil {
 		log.Fatalf("error: %s", err)
 	}
@@ -45,7 +45,7 @@ func main() {
 		for {
 			time.Sleep(30 * time.Second)
 
-			_, err = nat.AddPortMapping("tcp", 3080, "http", 60)
+			_, err = nat.AddPortMapping("tcp", 3080, "http", 60 * time.Second)
 			if err != nil {
 				log.Fatalf("error: %s", err)
 			}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	github.com/huin/goupnp v0.0.0-20180415215157-1395d1447324
 	github.com/jackpal/gateway v1.0.5
 	github.com/jackpal/go-nat-pmp v1.0.1
-	golang.org/x/net v0.0.0-20180524181706-dfa909b99c79
-	golang.org/x/text v0.3.0
+	github.com/koron/go-ssdp v0.0.0-20180514024734-4a0ed625a78b
+	golang.org/x/net v0.0.0-20180524181706-dfa909b99c79 // indirect
+	golang.org/x/text v0.3.0 // indirect
 )

--- a/nat.go
+++ b/nat.go
@@ -44,9 +44,6 @@ func DiscoverNATs(ctx context.Context) <-chan NAT {
 	go func() {
 		defer close(nats)
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
 		upnpIg1 := discoverUPNP_IG1(ctx)
 		upnpIg2 := discoverUPNP_IG2(ctx)
 		natpmp := discoverNATPMP(ctx)

--- a/nat.go
+++ b/nat.go
@@ -8,6 +8,8 @@ import (
 	"math/rand"
 	"net"
 	"time"
+
+	"github.com/jackpal/gateway"
 )
 
 var ErrNoExternalAddress = errors.New("no external address")
@@ -88,11 +90,37 @@ func DiscoverNATs(ctx context.Context) <-chan NAT {
 func DiscoverGateway() (NAT, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	nat := <-DiscoverNATs(ctx)
-	if nat == nil {
-		return nil, ErrNoNATFound
+
+	var nats []NAT
+	for nat := range DiscoverNATs(ctx) {
+		nats = append(nats, nat)
 	}
-	return nat, nil
+	switch len(nats) {
+	case 0:
+		return nil, ErrNoNATFound
+	case 1:
+		return nats[0], nil
+	}
+	gw, _ := gateway.DiscoverGateway()
+	bestNAT := nats[0]
+	natGw, _ := bestNAT.GetDeviceAddress()
+	bestNATIsGw := gw != nil && natGw.Equal(gw)
+	// 1. Prefer gateways discovered _last_. This is an OK heuristic for
+	// discovering the most-upstream (furthest) NAT.
+	// 2. Prefer gateways that actually match our known gateway address.
+	// Some relays like to claim to be NATs even if they aren't.
+	for _, nat := range nats[1:] {
+		natGw, _ := nat.GetDeviceAddress()
+		natIsGw := gw != nil && natGw.Equal(gw)
+
+		if bestNATIsGw && !natIsGw {
+			continue
+		}
+
+		bestNATIsGw = natIsGw
+		bestNAT = nat
+	}
+	return bestNAT, nil
 }
 
 func randomPort() int {


### PR DESCRIPTION
Default time unit is too short, and sometimes it will fail. Change to use time.Second.